### PR TITLE
APP-855 SDK Flutter não permite utilização de tokens públicos dinâmicos.

### DIFF
--- a/directcheckout/src/main/java/br/com/juno/directcheckout/DirectCheckout.kt
+++ b/directcheckout/src/main/java/br/com/juno/directcheckout/DirectCheckout.kt
@@ -198,13 +198,15 @@ object DirectCheckout {
 
     private fun loadPublicTokenMetadata(token: String?) {
         try {
-            if (!token.isNullOrEmpty()) {
-                publicToken = token
-            } else {
-                val ai = applicationContext.packageManager.getApplicationInfo(
-                    applicationContext.packageName, PackageManager.GET_META_DATA
-                )
-                if (!::publicToken.isInitialized) {
+            if (!::publicToken.isInitialized) {
+
+                if (!token.isNullOrEmpty()) {
+                    publicToken = token
+                } else {
+                    val ai = applicationContext.packageManager.getApplicationInfo(
+                        applicationContext.packageName, PackageManager.GET_META_DATA
+                    )
+
                     var tokenManifest = ai.metaData?.get(PUBLIC_TOKEN)
                     if (!prodEnvironment && ai.metaData.get(PUBLIC_TOKEN_SANDBOX) is String) {
                         tokenManifest = ai.metaData.get(PUBLIC_TOKEN_SANDBOX)

--- a/directcheckout/src/main/java/br/com/juno/directcheckout/DirectCheckout.kt
+++ b/directcheckout/src/main/java/br/com/juno/directcheckout/DirectCheckout.kt
@@ -203,13 +203,13 @@ object DirectCheckout {
                 if (!token.isNullOrEmpty()) {
                     publicToken = token
                 } else {
-                    val ai = applicationContext.packageManager.getApplicationInfo(
+                    val applicationInfo = applicationContext.packageManager.getApplicationInfo(
                         applicationContext.packageName, PackageManager.GET_META_DATA
                     )
 
-                    var tokenManifest = ai.metaData?.get(PUBLIC_TOKEN)
-                    if (!prodEnvironment && ai.metaData.get(PUBLIC_TOKEN_SANDBOX) is String) {
-                        tokenManifest = ai.metaData.get(PUBLIC_TOKEN_SANDBOX)
+                    var tokenManifest = applicationInfo.metaData?.get(PUBLIC_TOKEN)
+                    if (!prodEnvironment && applicationInfo.metaData.get(PUBLIC_TOKEN_SANDBOX) is String) {
+                        tokenManifest = applicationInfo.metaData.get(PUBLIC_TOKEN_SANDBOX)
                     }
                     if (tokenManifest is String) {
                         publicToken = tokenManifest


### PR DESCRIPTION
## O que
Foi solicitado que fosse ajustado no SDK o aceite de do token dinâmico além do que esta registrado no arquivo Manifest. 

## Por que
Alguns favorecidos precisam que seja passível considerar o token dinâmico. 

## Como
Foi mudado para aceitar o token na função de inicialização da classe. Ajustado na função o tratamento no caso já esteja inicializado o token e se o token dinâmico vier null ou vazio, será considerado o que esta registrado no Manifest

## Referências
[Issue APP-855](https://boleto.atlassian.net/browse/APP-855)